### PR TITLE
Queryset compatibility and other fixes, redone

### DIFF
--- a/osf_models/models/base.py
+++ b/osf_models/models/base.py
@@ -1,7 +1,10 @@
 import random
 
 import modularodm.exceptions
+from modularodm.query import QueryGroup
+
 from django.db import models
+from osf_models.modm_compat import to_django_query
 
 ALPHABET = '23456789abcdefghjkmnpqrstuvwxyz'
 
@@ -103,7 +106,7 @@ class BaseModel(models.Model):
     @classmethod
     def find_one(cls, query):
         try:
-            return cls.objects.get(query.to_django_query())
+            return cls.objects.get(to_django_query(query))
         except cls.DoesNotExist:
             raise modularodm.exceptions.NoResultsFound()
         except cls.MultipleObjectsReturned as e:
@@ -111,7 +114,7 @@ class BaseModel(models.Model):
 
     @classmethod
     def find(cls, query):
-        return cls.objects.filter(query.to_django_query())
+        return cls.objects.filter(to_django_query(query))
 
     @property
     def _primary_name(self):

--- a/osf_models/models/base.py
+++ b/osf_models/models/base.py
@@ -73,11 +73,11 @@ class BaseModel(models.Model):
         abstract = True
 
     @classmethod
-    def load(cls, id):
+    def load(cls, data):
         try:
             if issubclass(cls, GuidMixin):
-                return cls.objects.get(_guid__guid=id)
-            return cls.objects.getQ(pk=id)
+                return cls.objects.get(_guid__guid=data)
+            return cls.objects.getQ(pk=data)
         except cls.DoesNotExist:
             return None
 
@@ -93,3 +93,7 @@ class BaseModel(models.Model):
     @classmethod
     def find(cls, query):
         return cls.objects.filter(query.to_django_query())
+
+    @property
+    def _primary_name(self):
+        return '_id'

--- a/osf_models/models/base.py
+++ b/osf_models/models/base.py
@@ -67,8 +67,27 @@ class GuidMixin(models.Model):
     class Meta:
         abstract = True
 
+class MODMCompatibilityQuerySet(models.QuerySet):
+    def sort(self, *fields):
+        # Fields are passed in as e.g. [('title', 1), ('date_created', -1)]
+        if isinstance(fields[0], list):
+            fields = fields[0]
+        def sort_key(item):
+            if isinstance(item, basestring):
+                return item
+            elif isinstance(item, tuple):
+                field_name, direction = item
+                prefix = '-' if direction == -1 else ''
+                return ''.join([prefix, field_name])
+        sort_keys = [sort_key(each) for each in fields]
+        return self.order_by(*sort_keys)
+
+    def limit(self, n):
+        return self[:n]
 
 class BaseModel(models.Model):
+    objects = MODMCompatibilityQuerySet.as_manager()
+
     class Meta:
         abstract = True
 

--- a/osf_models/models/node.py
+++ b/osf_models/models/node.py
@@ -2,9 +2,9 @@ import urlparse
 
 from django.core.exceptions import ValidationError
 from django.db import models
-from modularodm import Q
 from typedmodels.models import TypedModel
 
+from osf_models.modm_compat import Q
 from osf_models.models import MetaSchema
 from osf_models.models.contributor import Contributor
 from osf_models.models.mixins import Loggable

--- a/osf_models/modm_compat.py
+++ b/osf_models/modm_compat.py
@@ -1,0 +1,127 @@
+# -*- coding: utf-8 -*-
+import sys
+from operator import and_, or_
+
+from django.db.models import Q as DjangoQ
+# from website import settings
+
+
+import modularodm
+from modularodm import Q as MODMQ
+from modularodm.query import query, QueryGroup
+
+
+class BaseQ(object):
+
+    def __or__(self, other):
+        return OrQ(self, other)
+
+    def __and__(self, other):
+        return AndQ(self, other)
+
+class CompoundQ(BaseQ, query.QueryGroup):
+
+    @property
+    def nodes(self):
+        return self.__queries
+
+    def __init__(self, *queries):
+        self.__queries = queries
+
+    def __repr__(self):
+        return '<{0}({1})>'.format(
+            self.__class__.__name__,
+            ', '.join(repr(node) for node in self.nodes)
+        )
+
+    @classmethod
+    def from_modm_query(cls, query):
+        op_function = and_ if query.operator == 'and' else or_
+        return reduce(op_function, (Q.from_modm_query(node) for node in query.nodes))
+
+class AndQ(CompoundQ):
+
+    operator = 'and'
+
+    def __and__(self, other):
+        return AndQ(other, *self.nodes)
+
+    def to_django_query(self):
+        return reduce(lambda acc, val: acc & val, (q.to_django_query() for q in self.nodes))
+
+class OrQ(CompoundQ):
+
+    operator = 'or'
+
+    def __or__(self, other):
+        return OrQ(other, *self.nodes)
+
+    def to_django_query(self):
+        return reduce(lambda acc, val: acc | val, (q.to_django_query() for q in self.nodes))
+
+class Q(BaseQ, query.RawQuery):
+    QUERY_MAP = {'eq': 'exact'}
+
+    @classmethod
+    def from_modm_query(cls, query):
+        if isinstance(query, QueryGroup):
+            compound_cls = AndQ if query.operator == 'and' else OrQ
+            return compound_cls.from_modm_query(query)
+        elif isinstance(query, MODMQ):
+            return cls(query.attribute, query.operator, query.argument)
+        elif isinstance(query, cls):
+            return query
+        else:
+            raise ValueError(
+                'from_modm_query must receive either a modularodm.Q, modularodm.query.QueryGroup, '
+                'or osf_models.modm_compat.Q object'
+            )
+
+    @property
+    def operator(self):
+        return self.__op
+
+    @property
+    def attribute(self):
+        return self.__key
+
+    @property
+    def argument(self):
+        return self.__val
+
+    @property
+    def op(self):
+        if self.__val is None:
+            return 'isnull'
+        return self.QUERY_MAP.get(self.__op, self.__op)
+
+    @property
+    def key(self):
+        if self.__key == '_id':
+            return 'pk'
+        return self.__key
+
+    @property
+    def val(self):
+        if self.__val is None:
+            return True if self.__op == 'eq' else False
+        return self.__val
+
+    def __init__(self, key, op, val):
+        self.__op = op
+        self.__key = key
+        self.__val = val
+
+    def to_django_query(self):
+        if self.op == 'ne':
+            return ~DjangoQ(**{'__'.join(self.key.split('.')): self.val})
+        return DjangoQ(**{'__'.join(self.key.split('.') + [self.op]): self.val})
+
+    def __repr__(self):
+        return '<Q({}, {}, {})>'.format(self.key, self.op, self.val)
+
+
+def to_django_query(query):
+    """Translate a modular-odm Q or QueryGroup to a Django query.
+    """
+    return Q.from_modm_query(query).to_django_query()


### PR DESCRIPTION
Replaces changes from #11 

-----

- Allow `.find()` and `find_one` to receive modularodm Q objects
- Adds `allow_institutions` param to Node.find for compat with legacy models
- Change `id` param of `load` to `data` for consistency with MODM. In some places in MODM, `data` is passed as a keyword argument
- Use a custom queryset with a `.sort` method for compatibility with MODM