### PR TITLE
Update move_contributor to work with django querysets

### DIFF
--- a/osf_models/models/node.py
+++ b/osf_models/models/node.py
@@ -958,8 +958,10 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
     def move_contributor(self, user, auth, index, save=False):
         if not self.has_permission(auth.user, ADMIN):
             raise PermissionsError('Only admins can modify contributor order')
-        old_index = self.contributors.index(user)
-        self.contributors.insert(index, self.contributors.pop(old_index))
+        contributor_ids = list(self.get_contributor_order())
+        old_index = contributor_ids.index(user.id)
+        contributor_ids.insert(index, contributor_ids.pop(old_index))
+        self.set_contributor_order(contributor_ids)
         self.add_log(
             action=NodeLog.CONTRIB_REORDERED,
             params={


### PR DESCRIPTION
The previous `move_contributor` node method was setup to work with previous contributor setup, which was a list instead of a queryset as it is now. Change just a few things to work with django querysets instead!