### PR TITLE
Fix return value of admin_contributor_ids property

### DIFF
--- a/osf_models/models/node.py
+++ b/osf_models/models/node.py
@@ -548,9 +548,9 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
             return Contributor.objects.select_related('user').filter(
                 user__is_active=True,
                 admin=True
-            ).values_list('user__guid__guid')
+            ).values_list('user__guid__guid', flat=True)
         contributor_ids = get_admin_contributor_ids(self)
-        admin_ids = set()
+        admin_ids = set(contributor_ids)
         for parent in self.parents:
             admins = get_admin_contributor_ids(parent)
             admin_ids.update(set(admins).difference(contributor_ids))


### PR DESCRIPTION
Before the `admin_contributor_ids` property would return an empty set, as the `contributor_ids` gathered from the original call of the inner `get_admin_contributor_ids` weren't included in the admin ids set update -- `contributor_ids` was exactly the same as what was returned in the for loop as `admins` - the resulting `admin_ids` set was empty.

Also include ` flat=True` when getting the value list. This updates the return value from something like `[(u'nugmw',), (u'ya24m',), (u'9cepr',)]` -- a list of tuples -- to something like `[u'nugmw', u'ya24m', u'9cepr']` -- a simple list of guids,  which is perhaps more expected