### PR TITLE
Allow meta for DraftRegistrationApproval to be blank for reject case

### DIFF
--- a/osf_models/models/sanctions.py
+++ b/osf_models/models/sanctions.py
@@ -836,7 +836,7 @@ class DraftRegistrationApproval(Sanction):
 
     # Since draft registrations that require approval are not immediately registered,
     # meta stores registration_choice and embargo_end_date (when applicable)
-    meta = DateTimeAwareJSONField(default=dict)
+    meta = DateTimeAwareJSONField(default=dict, blank=True)
 
     def _send_rejection_email(self, user, draft):
         schema = draft.registration_schema


### PR DESCRIPTION
`DraftRegistrationApproval`'s `_on_reject` [method explicitly sets](https://github.com/CenterForOpenScience/osf-models/blob/master/osf_models/models/sanctions.py#L898) `meta={}`, so allow for that in the django model too!

