### PR TITLE
Add timezone to be able to compare datetimes for embargoes 

### DIFF
--- a/osf_models/models/registrations.py
+++ b/osf_models/models/registrations.py
@@ -186,9 +186,8 @@ class Registration(AbstractNode):
 
     def _is_embargo_date_valid(self, end_date):
         now = timezone.now()
-        end_date_aware = end_date.replace(tzinfo=now.tzinfo)
-        if (end_date_aware - now) >= settings.EMBARGO_END_DATE_MIN:
-            if (end_date_aware - now) <= settings.EMBARGO_END_DATE_MAX:
+        if (end_date - now) >= settings.EMBARGO_END_DATE_MIN:
+            if (end_date - now) <= settings.EMBARGO_END_DATE_MAX:
                 return True
         return False
 

--- a/osf_models/models/registrations.py
+++ b/osf_models/models/registrations.py
@@ -186,8 +186,9 @@ class Registration(AbstractNode):
 
     def _is_embargo_date_valid(self, end_date):
         now = timezone.now()
-        if (end_date - now) >= settings.EMBARGO_END_DATE_MIN:
-            if (end_date - now) <= settings.EMBARGO_END_DATE_MAX:
+        end_date_aware = end_date.replace(tzinfo=now.tzinfo)
+        if (end_date_aware - now) >= settings.EMBARGO_END_DATE_MIN:
+            if (end_date_aware - now) <= settings.EMBARGO_END_DATE_MAX:
                 return True
         return False
 

--- a/osf_models/models/sanctions.py
+++ b/osf_models/models/sanctions.py
@@ -1,3 +1,4 @@
+import pytz
 import functools
 
 from dateutil.parser import parse as parse_date
@@ -882,10 +883,13 @@ class DraftRegistrationApproval(Sanction):
         if registration_choice == 'immediate':
             sanction = functools.partial(registration.require_approval, draft.initiator)
         elif registration_choice == 'embargo':
+            embargo_end_date = parse_date(self.meta.get('embargo_end_date'))
+            if not embargo_end_date.tzinfo:
+                embargo_end_date = embargo_end_date.replace(tzinfo=pytz.UTC)
             sanction = functools.partial(
                 registration.embargo_registration,
                 draft.initiator,
-                parse_date(self.meta.get('embargo_end_date'), ignoretz=True)
+                embargo_end_date
             )
         else:
             raise ValueError("'registration_choice' must be either 'embargo' or 'immediate'")


### PR DESCRIPTION
## Purpose
When comparing embargo dates, both sides need tzinfo - since [tzinfo is deliberately ignored earlier when parsing the end date](https://github.com/CenterForOpenScience/osf-models/blob/master/osf_models/models/sanctions.py#L888), thought here might be the best place for it?

## Changes
- Add UTC as tzinfo for the end_date for the embargo simply for comparison purposes