### PR TITLE
[Fix] Add missing `remove_user()` to `OSFUser` [#OSF-7068]

### DIFF
--- a/osf_models/models/user.py
+++ b/osf_models/models/user.py
@@ -880,6 +880,14 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel,
 
         return False
 
+    def remove_email(self, email):
+        """Remove a confirmed email"""
+        if email == self.username:
+            raise PermissionsError("Can't remove primary email")
+        if email in self.emails:
+            self.emails.remove(email)
+            signals.user_email_removed.send(self, email=email)
+
     def get_confirmation_token(self, email, force=False):
         """Return the confirmation token for a given email.
 


### PR DESCRIPTION
### Issue

@sloria 
User cannot remove email on account settings page.

### Fix

Add `remove_user()` to `OSFUser`.
It was in the `User` model in `famework/auth/core.py` but seems left out in `osf_models/models/user.py`.

### Side effect

No

### Ticket

https://openscience.atlassian.net/browse/OSF-7068