### PR TITLE
[Fix] Fix Timezone [#CAS-9]

### DIFF
--- a/osf_models/models/node.py
+++ b/osf_models/models/node.py
@@ -2278,7 +2278,7 @@ class AbstractNode(DirtyFieldsMixin, TypedModel, AddonModelMixin, IdentifierMixi
         # # there is no preprint file yet! This is the first time!
         # if not self.preprint_file:
         #     self.preprint_file = preprint_file
-        #     self.preprint_created = datetime.datetime.utcnow()
+        #     self.preprint_created = timezone.utcnow()
         #     self.add_log(action=NodeLog.PREPRINT_INITIATED, params={}, auth=auth, save=False)
         # elif preprint_file != self.preprint_file:
         #     # if there was one, check if it's a new file

--- a/osf_models/models/spam.py
+++ b/osf_models/models/spam.py
@@ -1,8 +1,8 @@
 import abc
 import logging
-from datetime import datetime
 
 from django.db import models
+from django.utils import timezone
 from osf_models.exceptions import ValidationValueError, ValidationTypeError
 from osf_models.utils.datetime_aware_jsonfield import DateTimeAwareJSONField
 
@@ -110,7 +110,7 @@ class SpamMixin(models.Model):
         if user == self.user:
             raise ValueError('User cannot report self.')
         self.flag_spam()
-        date = datetime.utcnow()
+        date = timezone.now()
         report = {'date': date, 'retracted': False}
         report.update(kwargs)
         if 'text' not in report:

--- a/osf_models/models/user.py
+++ b/osf_models/models/user.py
@@ -770,7 +770,7 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel,
         # Not all tokens are guaranteed to have expiration dates
         if (
             'expiration' in verification and
-            verification['expiration'] < dt.datetime.utcnow()
+            verification['expiration'] < timezone.now()
         ):
             raise ExpiredTokenError
 
@@ -913,7 +913,7 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel,
                 # Old records will not have an expiration key. If it's missing,
                 # assume the token is expired
                 expiration = info.get('expiration')
-                if not expiration or (expiration and expiration < dt.datetime.utcnow()):
+                if not expiration or (expiration and expiration < timezone.now()):
                     if not force:
                         raise ExpiredTokenError('Token for email "{0}" is expired'.format(email))
                     else:
@@ -1017,7 +1017,7 @@ class OSFUser(DirtyFieldsMixin, GuidMixin, BaseModel,
             used for testing purposes.
         """
         config = apps.get_app_config('osf_models')
-        expiration = expiration or (dt.datetime.utcnow() + dt.timedelta(hours=config.email_token_expiration))
+        expiration = expiration or (timezone.now() + dt.timedelta(hours=config.email_token_expiration))
         self.email_verifications[token]['expiration'] = expiration
         return expiration
 


### PR DESCRIPTION
### Purpose

Use `django.util.timezone.now()` instead of `datetime.datetime.utcnow()`.

### Side Effects

- [ ] Not sure if I should change occurrence in: 
https://github.com/CenterForOpenScience/osf-models/pull/142/commitshttps://github.com/CenterForOpenScience/osf-models/blob/master/osf_models/tests.py.

### Related PR

Django-OSF: https://github.com/CenterForOpenScience/osf.io/pull/6361

### Ticket
https://openscience.atlassian.net/browse/CAS-9