### PR TITLE
Don't allow comment content to be blank, to match validator

### DIFF
--- a/osf_models/models/comment.py
+++ b/osf_models/models/comment.py
@@ -49,8 +49,7 @@ class Comment(GuidMixin, SpamMixin, CommentableMixin, BaseModel):
     page = models.CharField(max_length=255, blank=True)
     content = models.TextField(
         validators=[validators.CommentMaxLength(settings.COMMENT_MAXLENGTH),
-                    validators.string_required],
-        blank=True
+                    validators.string_required]
     )
 
     # The mentioned users


### PR DESCRIPTION
Don't allow comment content to be blank, as this is not allowed in the old model and also is caught in the [validators here ](https://github.com/CenterForOpenScience/osf-models/blob/master/osf_models/models/validators.py#L14)

having `blank=True` was allowing comments to be blank, despite the model validator to the contrary!