### PR TITLE
Make sure get_node_comment_timestamps has tz aware timestamps

### DIFF
--- a/osf_models/models/comment.py
+++ b/osf_models/models/comment.py
@@ -1,4 +1,8 @@
+<<<<<<< Updated upstream
 
+=======
+import pytz
+>>>>>>> Stashed changes
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
 from django.db.models import Q
@@ -134,9 +138,14 @@ class Comment(GuidMixin, SpamMixin, CommentableMixin, BaseModel):
             else:
                 raise ValueError('Invalid page')
 
+            if not view_timestamp.tzinfo:
+                view_timestamp = view_timestamp.replace(tzinfo=pytz.utc)
+
             return cls.objects.filter(
-                Q(node=node) & ~Q(user=user) & Q(is_deleted=False) &
-                (Q(date_created__gt=view_timestamp) | Q(date_modified__gt=view_timestamp)) &
+                Q(node=node) & ~Q(user=user) &
+                Q(is_deleted=False) &
+                (Q(date_created__gt=view_timestamp) |
+                 Q(date_modified__gt=view_timestamp)) &
                 Q(root_target=root_target)
             ).count()
 

--- a/osf_models/models/comment.py
+++ b/osf_models/models/comment.py
@@ -1,8 +1,5 @@
-<<<<<<< Updated upstream
 
-=======
 import pytz
->>>>>>> Stashed changes
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
 from django.db.models import Q
@@ -142,10 +139,8 @@ class Comment(GuidMixin, SpamMixin, CommentableMixin, BaseModel):
                 view_timestamp = view_timestamp.replace(tzinfo=pytz.utc)
 
             return cls.objects.filter(
-                Q(node=node) & ~Q(user=user) &
-                Q(is_deleted=False) &
-                (Q(date_created__gt=view_timestamp) |
-                 Q(date_modified__gt=view_timestamp)) &
+                Q(node=node) & ~Q(user=user) & Q(is_deleted=False) &
+                (Q(date_created__gt=view_timestamp) | Q(date_modified__gt=view_timestamp)) &
                 Q(root_target=root_target)
             ).count()
 


### PR DESCRIPTION
The user method`get_node_comment_timestamps` in the [new models returns a tz aware timestamp](get_node_comment_timestamps). However, `get_node_comment_timestamps` in the [old models was not timezone aware and so does not](https://github.com/CenterForOpenScience/osf.io/blob/develop/framework/auth/core.py#L1625). 

Make sure the correct utz timestamp is added here to make sure the timestamp filtering can happen for updated comments and unread counts.